### PR TITLE
Fix: error in shape_extra and bone loading

### DIFF
--- a/amr/datasets/animal3d_dataset.py
+++ b/amr/datasets/animal3d_dataset.py
@@ -55,7 +55,7 @@ class Train3DDataset(Dataset):
         bbox = data['bbox']  # [x, y, w, h]
         center = np.array([(bbox[0] * 2 + bbox[2]) // 2, (bbox[1] * 2 + bbox[3]) // 2])
         pose = np.array(data['pose'], dtype=np.float32)  # [105, ]
-        betas = np.array(data['shape'], dtype=np.float32)  # [41, ]
+        betas = np.array(data['shape'] + data['shape_extra'], dtype=np.float32) if 'shape_extra' in data else betas = np.array(data['shape'], dtype=np.float32) #[41,]
         translation = np.array(data['trans'], dtype=np.float32)  # [3, ]
         has_pose = np.array(1., dtype=np.float32)
         has_betas = np.array(1., dtype=np.float32)


### PR DESCRIPTION
Fix: removing data['shape_extra'] in betas and ensuring correct loading of smal_params['bone'] as mentioned in issue